### PR TITLE
fixing docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./codebase/api:/usr/api
     env_file:
-      - path: ./environments/.api
+      - ./environments/.api
     command: >
       bash -c "cd /usr/api &&
         yarn &&


### PR DESCRIPTION
Note sure if it is local problem but while trying to run `docker compose up` i got the error:

`validating .../docker-compose.yaml: services.doteducation-api.env_file.0 must be a string`

And changing `env_files` as a list of strings fixed the issue for me

If it's just a local issue we can close this one