### PR TITLE
Unlink node modules from host

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ docker compose --profile slim up
 ```
 
 ### 4. Shutdown Docker Compose
-To stop all containers, networks, and volumes created by Docker Compose, run:
+To stop and remove all containers, networks, and volumes (both named & anonymous) created by Docker Compose, run:
 ```bash
-docker compose down
+docker compose down -v
+```
+
+If you want to remove only the anonymous volumes, stop the containers and run:
+```bash
+docker-compose rm -vf
 ```
 
 ### 5. (Optional) Setup a script to start working

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - 4000:4000
     volumes:
       - ./codebase/api:/usr/api
+      - /usr/api/node_modules
     env_file:
       - ./environments/.api
     command: >


### PR DESCRIPTION
This PR unlinks `node_modules` from the host machine to the docker container, preventing `bcrypt` dependency on the API from failing.